### PR TITLE
feat: api changes

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -3,130 +3,222 @@
 import { Scribe, StatusInterpretationCode } from "."
 
 export = (): void => {
-    describe("creating a new ScribeRuntime", () => {
-        const Beatriz_Id = "BEATRIZ_ID"
+    describe("the build a Scribe runtime", () => {
+        it("should build correctly", () => {
+            const ScribeRuntime = Scribe.load(`
+                $echo("Hello, world!") # This should output at first.
+            `, {})
+
+            const statusCode = ScribeRuntime.start()
+
+            expect(statusCode).to.be.equal(StatusInterpretationCode.OK)
+        })
+
+        it("should declare/start scenes correctly", () => {
+            const ScribeRuntime = Scribe.load(`
+                scene FIRST_SCENE {
+                    $echo("First scene was ran correctly!")
+                }
+                
+                do {
+                    start FIRST_SCENE
+                }
+            `, {})
+
+            expect((): void => void ScribeRuntime.start()).to.never.throw()
+        })
+
+        it("should declare & interact with interactions correctly", () => {
+            const ScribeRuntime = Scribe.load(`
+                actor TESTING_ACTOR "SiriusLatte" # Easter egg I guess?
+
+                scene MY_SCENE {
+                    $echo("Scene correctly started from interaction.")
+                }
+
+                interact TESTING_ACTOR {
+                    start MY_SCENE
+                }
+            `, {})
+
+            const statusCode = ScribeRuntime.start()
+            if (statusCode !== StatusInterpretationCode.OK) throw `Execution failed before interacting with any actors.`
+
+            expect(() => ScribeRuntime.interact("SiriusLatte")).to.never.throw()
+        })
+
+        it("should handle dialogs correctly", () => {
+            const ScribeRuntime = Scribe.load(`
+                actor ACTOR 0
+
+                scene SCENE {
+                    [ACTOR] "Hello there!" (5s) with {
+                        option "Hello, how are you?" {
+                            [ACTOR] "I'm fine, thank you." (5s)
+                        }
+                    }
+                }
+
+                interact ACTOR {
+                    start SCENE
+                }
+            `, {})
+
+            expect(
+                () => {
+                    ScribeRuntime.onDialog = ({characterIdentifier, options}, step): void => {
+                        print(`Actor triggering this dialog: ${characterIdentifier}. Options: ${options}`)
+
+                        if (options.size() > 0) {
+                            step()
+                        }
+                    }
+
+                    ScribeRuntime.start()
+                }
+            ).to.never.throw()
+        })
+
+        it("should trigger an store (from Scribe & API)", () => {
+            const ScribeRuntime = Scribe.load(`
+                store id LINKING_ID 0
+                store isApiCall API false
+
+                actor ACTOR 0
+
+                trigger [id] {
+                    $echo($format("Store was modified correctly. {}", isApiCall -> "Modified from the API." : "Modified from Scribe."))
+                }
+
+                interact ACTOR {
+                    set id 1
+                }
+            `, {})
+
+            expect(
+                () => {
+                    ScribeRuntime.onChange = ({ identifier, newValue, oldValue }): void => {
+                        print(`Store changed: ${identifier}. Latest value: ${newValue}. Last value registered: ${oldValue}`)
+                    }
+
+                    ScribeRuntime.start()
+                    
+                    {
+                        ScribeRuntime.setStore("isApiCall", true)
+                        ScribeRuntime.setStore("id", 10)
+                    }
+                }
+            ).to.never.throw()
+        })
+
+        it("should test control statements correctly", () => {
+            const ScribeRuntime = Scribe.load(`
+                store _0 _ true
+                store _1 _ _0 -> "This message should be given." : "This won't be shown."
+
+                if {
+                    _0 -> {
+                        $echo(_1)
+
+                        set _0 false
+                    }
+
+                    otherwise -> {
+                        $echo("This won't be ran!")
+                    }
+                }
+
+                do {
+                    if (_0) {
+                        $echo ("This won't be shown.")
+                    } else {
+                        $echo($format("Seemes like variable _0 has changed it's value to {}", _0))
+                    }
+                }
+            `, {})
+
+            expect((): void => void ScribeRuntime.start()).to.never.throw()
+        })
+    })
+
+    describe("a quest", () => {
         const ScribeRuntime = Scribe.load(`
-            property title "Testing property"
-
-            actor BEATRIZ $testing_id
-
-            store sticks STICKS_COLLECTED 0
-            store isFinished FLAG false
-
-            store undefined_store UNDEFINED undefined
-
-            default objective first_objective "Default description"
-            objective some_objective "Some other description"
-
-            scene MY_SCENE {
-                [BEATRIZ] "Testing dialogs." (2s, "Hello, world!") with {
-                    option "Option's dialog text." {
-                        $echo("Stepped on the first option correctly!")
-
-                        set sticks (sticks + 1)
-                    }
-                }
-
-                if true {
-                    $echo("If statement first variant passed correctly.")
-                }
-
-                if false {
-                    $echo("This will not output.")
-                } else {
-                    $echo("Else statement working correctly.")
-                }
-
-                if {
-                    true == true -> {
-                        $echo("If statement condition passed correctly.")
-                    }
-
-                    otherwise -> {
-                        $echo("This otherwise shouldn't be ran.")
-                    }
-                }
-
-                if {
-                    false == true -> {}
-
-                    otherwise -> {
-                        $echo("If statement conditions failed, otherwise tested correctly.")
-                    }
-                }
-            }
+            property title $format("Gather sticks for {}", $actor)
             
-            scene API_SCENE {
-                $echo("Correctly played API scene.")
+            store isFrend ACTOR_TRACK false
+
+            actor SIRIUS $actor
+            actor FRIEND "frend"
+
+            default objective TALK_TO_SIRIUS "The man isn't that scary! C'mon, go talk to him."
+            objective RUN "HE BITES, I WAS WRONG, JUST RUN!"
+            objective DONE "Oh, I didn't know he was chill like that."
+
+            scene TALKING_TO {
+                [SIRIUS] "Hey there! Nice to meet you." (5s) with {
+                    option "Nice to meet you too! Who are you by the way?" {
+                        [SIRIUS] "I'm SiriusLatte, the creator of Scribe (and MkScribe). I'm here to GATHER your SOUL." with {
+                            option "Uh... Could you repeat that last part...?" {
+                                [SIRIUS] "Sure! I said, I'M HERE TO GATHER YOUR SOUL!" (5s)
+
+                                start RUN
+                            }
+                        }
+                    }
+
+                    option "Huh, such a random dude." {
+                        [SIRIUS] "You know what? I didn't even wanted to talk with someone like you."
+                    }
+                }
             }
 
-            interact BEATRIZ {
-                start MY_SCENE
+            scene RUNNING {
+                if (isFrend) {
+                    [FRIEND] "DUDE, DON'T LOOK BACK, JUST KEEP RUNNING!" (15s)
+                    [FRIEND] "Okey... I think we lost him. Do you see it?" with {
+                        option "It's right behind you..." {
+                            [FRIEND] "NOOOOO, RUN, I'M DONE!" (5s)
+                        }
+                    }
+                } else {
+                    [SIRIUS] "HAHAHAHAHA, YOU CAN RUN, BUT I'LL CATCH YOU ANYWAY! IT'S USELESS, STOP RIGHT NOW!" (10s) with {
+                        option "GO AWAY DUDE!" {
+                            [SIRIUS] "Oh okey, sure thing bud" (5s)
+
+                            start DONE
+                        }
+                    }
+                }
             }
 
-            trigger sticks {
-                $echo("Stick's value changed!")
+            interact SIRIUS {
+                if {
+                    TALK_TO_SIRIUS -> { start TALKING_TO }
 
-                start some_objective
+                    otherwise -> { start RUNNING }
+                }
             }
 
-            do {
-                # Simple do statement, testing the syntax + comment test
+            interact FRIEND {
+                if {
+                    RUN -> { start RUNNING }
 
-                $echo("Formatting the next piece of text..." $format("Hello, {}", "world!"))
-                $echo("Undefined testing", not undefined_store -> "This shouldn't be it!" : "This is alright!", undefined_store, not undefined_store == false)
+                    DONE -> { $echo("I didn't know he was chill like that, lets leave now.") }
+                }
             }
-
         `, {
-            testing_id: Beatriz_Id
+            actor: "SiriusLatte"
         })
 
-        it("should not throw when instantiating a new ScribeRuntime.", () => {
-            expect(() => Scribe.load("", {})).never.to.throw()
-        })
+        it("should start quest correctly", () => {
+            ScribeRuntime.onDialog = (): void => {}
+            ScribeRuntime.onChange = (): void => {}
 
-        it("should correctly bind the given callbacks", () => {
-            ScribeRuntime.onDialog = ({ characterIdentifier, step }) => {
-                expect(characterIdentifier).to.be.equal("BEATRIZ")
-
-                step(1)
+            ScribeRuntime.onEndExecution = (): void => {
+                print("Describing quest has been finished correctly.")
             }
 
-            ScribeRuntime.onChange = ({ data }) => {
-                expect(data).to.be.equal(1)
-            }
-
-            ScribeRuntime.onObjectiveChange = ({ id }) => {
-                expect(id).to.be.equal("some_objective")
-            }
-
-            ScribeRuntime.onExit = ({ output }) => {
-                expect(output).to.be.equal(1) // Correct exit of the program
-            }
-        })
-
-        it("should start/initialize the runtime correctly", () => {
-            expect(ScribeRuntime.start()).to.be.equal(StatusInterpretationCode.OK)
-        })
-
-        it("should verify properties correct declaration", () => {
-            expect(ScribeRuntime.getProperties().title).to.be.ok()
-        })
-
-        it("should interact correctly with one actor", () => {
-            expect(() => ScribeRuntime.interact(Beatriz_Id)).never.to.throw()
-        })
-
-        it("should check for the current objective", () => {
-            expect(ScribeRuntime.getCurrentObjective()?.id).to.be.equal(2) // The second objective
-        })
-
-        it("should play a scene correctly", () => {
-            expect(() => ScribeRuntime.play("API_SCENE")).never.to.throw()
-        })
-
-        it("should change a store's value correctly", () => {
-            expect(() => ScribeRuntime.setStore("FLAG", true))
+            expect((): void => void ScribeRuntime.start()).to.never.throw()
         })
     })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import { ModuleSource, ScribeEnviroment, StringSource, StringValueSource } from 
 export namespace Scribe {
 	export function load(file: string | StringValue | ModuleScript, env: ScribeEnviroment): Runtime {
 		const toRetrieveFrom = typeOf(file);
-		let source!: string;
 
+		let source!: string;
 		switch (toRetrieveFrom) {
 			case "Instance": {
 				if ((file as Instance).IsA("ModuleScript")) {

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -33,13 +33,12 @@ export declare type DialogCallbackInput = {
 	text: TokenLiteral;
 	metadata: ScribeMetadata;
 	options: Array<OptionStructure>;
-
-	step: (id?: number) => void;
 };
 
 export declare type PipeToCallbackInput = {
 	identifier: string;
-	data: unknown;
+	newValue: unknown;
+	oldValue?: unknown;
 	metadata: ScribeMetadata;
 };
 
@@ -52,13 +51,13 @@ export declare type ExitCallbackInput = {
 	output: TokenLiteral | undefined;
 };
 
-export interface ScribeRuntimeImplementation {
+export interface ScribeCallbacks {
 	/**
-	 * A callback to handle dialog.
+	 * A callback binded to handle dialog.
 	 *
 	 * @param input DialogCallbackInput (an object containing all of the dialog info)
 	 */
-	onDialog?: (input: DialogCallbackInput, step: (id: number) => void) => void;
+	onDialog?: (input: DialogCallbackInput, step: (id?: number) => void) => void;
 
 	/**
 	 * A callback binded to handle store's values changes.
@@ -79,72 +78,11 @@ export interface ScribeRuntimeImplementation {
 	 * the Scribe program.
 	 *
 	 * @param input ExitCallbackInput (an object containing the optional output of the program)
-	 * @returns
 	 */
 	onExit?: (input: ExitCallbackInput) => void;
 
-	onEndExecution?: () => void;
-
 	/**
-	 * Starts the Runtime.
-	 *
-	 * Workflow is to set `pipeTo` and `dialogCallback` before running `.start`.
+	 * A callback binded to handle the end execution of the program, when Scribe it is done running.
 	 */
-	start(): StatusInterpretationCode;
-
-	getObjective(objective: string): Objective | undefined;
-
-	/**
-	 *
-	 */
-	getCurrentObjective(): Objective | undefined;
-
-	/**
-	 * Retrieve's a property's value.
-	 *
-	 * @param property string
-	 */
-	getProperty(property: string): TokenLiteral;
-
-	/**
-	 * @returns all the Program properties.
-	 */
-	getProperties(): ScribeProgramProperties;
-
-	/**
-	 * Method to increment a store's value.
-	 *
-	 * @param valueTo string
-	 * @param increment number
-	 */
-	incrementStore(valueTo: string, increment: number): void;
-
-	/**
-	 * Method to set a store's value.
-	 *
-	 * @param valueTo string
-	 * @param value unknown
-	 */
-	setStore(valueTo: string, value: unknown): void;
-
-	/**
-	 * Sets the current objective, another util function.
-	 *
-	 * @param objective string
-	 */
-	setCurrentObjective(objective: string): void;
-
-	/**
-	 * Resolves a scene by "playing" it.
-	 *
-	 * @param scene string
-	 */
-	play(scene: string): void;
-
-	/**
-	 * Initialises an interaction statement.
-	 *
-	 * @param id actor's id.
-	 */
-	interact(id: string): void;
+	onEndExecution?: (statusCode: StatusInterpretationCode) => void;
 }

--- a/src/runtime/visitor/types.d.ts
+++ b/src/runtime/visitor/types.d.ts
@@ -1,8 +1,7 @@
 import { ExpressionVisitor, StatementVisitor } from "@aethergames/mkscribe";
 import { TokenLiteral } from "@aethergames/mkscribe/out/mkscribe/scanner/types";
 
-export declare type RefNode = {
-	refValue: TokenLiteral;
+declare type RefNode = {
 	ref: string;
 	_next: RefNode;
 };


### PR DESCRIPTION
API & Type changes suggested, as opposed in previous versions of Scribe, now setting/incrementing an store from the API will also invoke the trigger related to said store.

Some type changes were made, the most important (and which breaks current Scribe code) it's within the `onDialog` callback, `step` function has been moved outside of the destructuring object to being its own separate parameter.
```ts
ScribeRuntime.onDialog = ({ ... }, step): void => {
    ...
}
```

Aside from that, all methods and callbacks remain the same. Except `onEndExecution`, the bind has been modified/added to Scribe's execution scheme. 
```ts
ScribeRuntime.onEndExecution = (code: StatusInterpretationCode): void => {
    ...
}
```

Such bind it's invoked every time `.start()` is finished. The status code is not replaced within the `onEndExecution` bind from the return on the `.start()` method, but rather as a way of knowing the output from your Scribe's program.

Regarding triggers and their changes, now triggers will be invoked even from outside API calls (such as `.incrementStore` and `.setStore`). Scribe program:
```py
# Scribe's program

store id LINK 0

trigger id {
    $echo($format("Changed id! New value: {}", id)) # Changed id! New value: 5
}
```

TypeScript program:
```ts
const ScribeRuntime = Scribe.load(...);

ScribeRuntime.incrementStore("id", 5); // We will see the echo
```

Also, did you notice? If not, go back and see this line `ScribeRuntime.incrementStore("id", 5);`, that's right. Now you can increment/set unique stores from their ids, though you can still modify all linked stores from their Linking Reference. This doesn't break any Scribe's current code, but rather adds another way of modifying Scribe's environment easily.